### PR TITLE
Add invert state configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,25 @@ Here's how to configure a set of switches :
         "accessory": "Chacon",
         "name": "Switch2",
         "deviceId": 2,
-        "emitterId": 12325261
+        "emitterId": 12325261,
+        "dimmable": true
     },
     {
         "accessory": "Chacon",
         "name": "Switch3",
         "deviceId": 3,
-        "emitterId": 12325261
+        "emitterId": 12325261,
+        "invert": "true"
     }
     ]
 
 Each accessory have a unique deviceId that is transmitted during the learning process, 
 the emitterId bounds a switch to that emitter, a switch can have multiple emitter associated (a remote control).
+
+Options :
+
+* dimmable : register the switch as dimmable lightbulb
+* invert : invert the state of switch (turn on -> off, turn off -> on), this configuration is used in case of electric heater setup (see: http://www.planete-domotique.com/blog/2012/01/05/piloter-un-radiateur-grace-a-son-fil-pilote/)
 
 ### Learning process
 The learning process is actually the same as described in the guide of the switch seller. A 'on' code has to be sent to the switch

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function ChaconAccessory(log, config) {
   this.deviceId     = config['deviceId'];
   this.emitterId    = config['emitterId'];
   this.isDimmable   = config['dimmable'];
+  this.isInverted   = config['invert']
   if (noInitDone) {
     chaconEmitter.init();
     noInitDone = false;
@@ -23,7 +24,7 @@ function ChaconAccessory(log, config) {
 ChaconAccessory.prototype = {
   setPowerState: function(powerOn, callback) {
     var that = this;
-    var order = chaconEmitter.buildOrder(this.emitterId, this.deviceId, powerOn);
+    var order = chaconEmitter.buildOrder(this.emitterId, this.deviceId, this.isInverted == "true" ? !powerOn : powerOn);
     chaconEmitter.transmit(order);
     callback(null);
   },
@@ -38,16 +39,13 @@ ChaconAccessory.prototype = {
   getServices: function() {
     var switchService = new Service.Switch(this.name);
     var lightBulb = new Service.Lightbulb(this.name);
-    //var informationService = new Service.AccessoryInformation();
-
-    /* informationService
-      .setCharacteristic(Characteristic.Manufacturer, this.manufacturer)
-      .setCharacteristic(Characteristic.Model, this.model_name)
-      .setCharacteristic(Characteristic.SerialNumber, this.id);
-    */
+    
     switchService
       .getCharacteristic(Characteristic.On)
       .on('set', this.setPowerState.bind(this));
+    if(this.isInverted == "true") {
+      switchService.setCharacteristic(Characteristic.On, true)
+    }
     lightBulb
       .getCharacteristic(Characteristic.On)
       .on('set', this.setPowerState.bind(this));


### PR DESCRIPTION
This option can be used to invert switch state. It is usefull in case of electric heater setup where open circuit is equal to an "on" state.