### PR TITLE
Bump to node-wiring-pi 0.0.4 with external wiringPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ This plugin uses extensively the WiringPi lib to communicate with GPIO ports of
 the raspberry. This plugin is compatible with RF433 emitter wired to the Raspberry.
 
 ## How to install
+
+1. Install homebridge using: `npm install -g homebridge`
+2. Install wiringPi using: `sudo apt-get install wiringpi`
+3. Add rights to homebridge user if running homebridge as systemd service: `sudo usermod -G gpio homebridge`
+4. Install this plugin using: `npm install -g homebridge-rpi-chacon`
+
 ## How to use
 
 ### Configuration

--- a/chaconEmitter.js
+++ b/chaconEmitter.js
@@ -1,4 +1,4 @@
-var wpi = require('wiringpi-node')
+var wpi = require('node-wiring-pi')
 
 var pin = 0;
 var dimLevels = 15;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "wiringpi-node": "^2.4.4"
+    "node-wiring-pi": "^0.0.4"
   },
   "keywords": [
     "RF433",


### PR DESCRIPTION
Fix issues with wiringPi 2.44 and RPI3+ by allowing fresh wiringPi installation with `sudo apt-get install wiringpi`